### PR TITLE
Fix ResourceWarning about unclose file in _get_traceback_files

### DIFF
--- a/pydump.py
+++ b/pydump.py
@@ -192,7 +192,8 @@ def _get_traceback_files(traceback):
             filename = os.path.abspath(frame.f_code.co_filename)
             if filename not in files:
                 try:
-                    files[filename] = open(filename).read()
+                    with open(filename) as f:
+                        files[filename] = f.read()
                 except IOError:
                     files[
                         filename


### PR DESCRIPTION
After reading the contents of file, we close it. `with` statement is handy in this situation