### PR TITLE
Python 3 bug fixes

### DIFF
--- a/pydump.py
+++ b/pydump.py
@@ -138,6 +138,10 @@ class FakeCode(object):
         self.co_lnotab = code.co_lnotab
         self.co_varnames = code.co_varnames
         self.co_flags = code.co_flags
+        self._co_lines = list(code.co_lines()) if hasattr(code, 'co_lines') else []
+
+    def co_lines(self):
+        return iter(self._co_lines)
 
 
 class FakeFrame(object):

--- a/pydump.py
+++ b/pydump.py
@@ -139,6 +139,8 @@ class FakeCode(object):
         self.co_varnames = code.co_varnames
         self.co_flags = code.co_flags
         self._co_lines = list(code.co_lines()) if hasattr(code, 'co_lines') else []
+        if hasattr(code, 'co_kwonlyargcount'):
+            self.co_kwonlyargcount = code.co_kwonlyargcount
 
     def co_lines(self):
         return iter(self._co_lines)


### PR DESCRIPTION
Contains two python 3 related fixes:

1. Fixes for crash pdb tries to use the FakeCode during loading of a dump in python 3.10
2. The pdb args command, which since python 3.8 requires co_kwonlyargcount to be available in the code objects

Fixes #11